### PR TITLE
fix: modify the configuration of hugo's google analytics to the correct one

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,12 +32,12 @@ theme = "LoveIt"
     Devto = "devstream"
     RSS = true
   #  Google网站分析配置
-  [analytics]
+  [params.analytics]
     enable = true
     # Google Analytics
-  [analytics.google]
+  [params.analytics.google]
     id = "G-GW88B1KC6Z"
-    # 是否匿名化用户 IP
+    # whether to anonymize IP
     anonymizeIP = true
   [params.section]
     # special amount of posts in each section page


### PR DESCRIPTION
Signed-off-by: KeHaoKH <hao.ke@merico.dev>

## Description

modify the configuration of Hugo's google analytics to the correct one. By using the same HUGO and the same LoveIt theme in my personal blog under the framework of google analytics verification found that this configuration should be used